### PR TITLE
Add ShellCheck CI workflow

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,19 @@
+name: ShellCheck
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Run ShellCheck
+      uses: ludeeus/action-shellcheck@2.0.0
+      with:
+        check_together: 'yes'
+        severity: error

--- a/executable_git
+++ b/executable_git
@@ -80,7 +80,8 @@ find_real_git() {
     done
 
     # If not found in common locations, search PATH excluding our own directory
-    local our_dir=$(dirname "$0")
+    local our_dir
+    our_dir=$(dirname "$0")
     local IFS=:
     for dir in $PATH; do
         if [ "$dir" != "$our_dir" ] && [ -x "$dir/git" ]; then
@@ -98,8 +99,10 @@ GIT_BIN=$(find_real_git)
 
 # Function to get configured git user for signoff
 get_git_signoff() {
-    local git_name=$("$GIT_BIN" config user.name 2>/dev/null)
-    local git_email=$("$GIT_BIN" config user.email 2>/dev/null)
+    local git_name
+    local git_email
+    git_name=$("$GIT_BIN" config user.name 2>/dev/null)
+    git_email=$("$GIT_BIN" config user.email 2>/dev/null)
 
     if [ -n "$git_name" ] && [ -n "$git_email" ]; then
         echo "Signed-off-by: $git_name <$git_email>"


### PR DESCRIPTION
## Summary
- Added GitHub Actions workflow to run ShellCheck on all shell scripts in the repository
- Fixed existing ShellCheck warnings (SC2155) in `executable_git` by separating variable declaration from assignment
- Configured ShellCheck to run on all pushes and pull requests to the main branch

## Test plan
- [x] Ran ShellCheck locally to verify no warnings remain
- [ ] GitHub Actions workflow will run on this PR to validate the setup
- [ ] Merge will ensure all future shell scripts are automatically checked

🤖 Generated with Claude Code (https://claude.ai/code)