### PR TITLE
Enhance commit signoff with disapproval mode for lazy cheater flag

### DIFF
--- a/executable_git
+++ b/executable_git
@@ -98,13 +98,22 @@ GIT_BIN=$(find_real_git)
 
 # Function to get configured git user for signoff
 get_git_signoff() {
+    local mode="${1:-signoff}"  # "signoff" or "disapprove"
     local git_name=$("$GIT_BIN" config user.name 2>/dev/null)
     local git_email=$("$GIT_BIN" config user.email 2>/dev/null)
 
-    if [ -n "$git_name" ] && [ -n "$git_email" ]; then
-        echo "Signed-off-by: $git_name <$git_email>"
+    if [ "$mode" = "disapprove" ]; then
+        if [ -n "$git_name" ] && [ -n "$git_email" ]; then
+            echo "Grudgingly-Disapproved-By: $git_name <$git_email>"
+        else
+            echo "Grudgingly-Disapproved-By: Unknown User <unknown@example.com>"
+        fi
     else
-        echo "Signed-off-by: Unknown User <unknown@example.com>"
+        if [ -n "$git_name" ] && [ -n "$git_email" ]; then
+            echo "Signed-off-by: $git_name <$git_email>"
+        else
+            echo "Signed-off-by: Unknown User <unknown@example.com>"
+        fi
     fi
 }
 
@@ -244,7 +253,11 @@ if [ "$1" = "commit" ]; then
                 -c "user.email=noreply@anthropic.com"
                 -c "commit.gpgsign=false"
             )
-            signoff=$(get_git_signoff)
+            if [ "$has_lazy_cheater_flag" = true ]; then
+                signoff=$(get_git_signoff "disapprove")
+            else
+                signoff=$(get_git_signoff)
+            fi
             ;;
         "zed")
             extra_args=(
@@ -252,7 +265,11 @@ if [ "$1" = "commit" ]; then
                 -c "user.email=noreply@zed.dev"
                 -c "commit.gpgsign=false"
             )
-            signoff=$(get_git_signoff)
+            if [ "$has_lazy_cheater_flag" = true ]; then
+                signoff=$(get_git_signoff "disapprove")
+            else
+                signoff=$(get_git_signoff)
+            fi
             ;;
         "opencode")
             extra_args=(
@@ -260,7 +277,11 @@ if [ "$1" = "commit" ]; then
                 -c "user.email=noreply@opencode.ai"
                 -c "commit.gpgsign=false"
             )
-            signoff=$(get_git_signoff)
+            if [ "$has_lazy_cheater_flag" = true ]; then
+                signoff=$(get_git_signoff "disapprove")
+            else
+                signoff=$(get_git_signoff)
+            fi
             ;;
         "cursor")
             extra_args=(
@@ -268,7 +289,11 @@ if [ "$1" = "commit" ]; then
                 -c "user.email=cursoragent@cursor.com"
                 -c "commit.gpgsign=false"
             )
-            signoff=$(get_git_signoff)
+            if [ "$has_lazy_cheater_flag" = true ]; then
+                signoff=$(get_git_signoff "disapprove")
+            else
+                signoff=$(get_git_signoff)
+            fi
             ;;
         *)
             # Regular commit - no special handling
@@ -320,6 +345,9 @@ if [ "$1" = "commit" ]; then
 🤖 SHAME: This commit was made by $ai_tool who was too lazy to fix the commit hooks properly." >> "$tmpfile"
         fi
         echo "" >> "$tmpfile"
+        if [ "$has_lazy_cheater_flag" = true ]; then
+            signoff=$(get_git_signoff "disapprove")
+        fi
         echo "$signoff" >> "$tmpfile"
         commit_args+=(--template "$tmpfile")
 


### PR DESCRIPTION
## Summary
- Adds a "disapprove" mode to the git signoff function to mark commits as grudgingly disapproved
- Applies disapproval signoff when the lazy cheater flag is detected during commits
- Provides fallback user info for disapproval signoff if git user config is missing

## Changes

### Commit Signoff Logic
- Modified `get_git_signoff` function to accept a mode parameter (`signoff` or `disapprove`)
- Outputs `Grudgingly-Disapproved-By` header when in disapprove mode
- Falls back to `Unknown User <unknown@example.com>` if user name/email are not configured

### Commit Hook Integration
- Updated commit handling to check for `has_lazy_cheater_flag`
- Uses disapprove signoff when the flag is true, otherwise uses regular signoff
- Ensures disapproval signoff is appended to commit message template when applicable

## Test plan
- Verified commits with and without lazy cheater flag produce correct signoff headers
- Confirmed fallback user info appears when git user config is missing
- Tested commit message templates include appropriate signoff lines based on flag state

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b151d96e-4033-4289-a438-a9d032b95b3e