### PR TITLE
Fix install.sh upgrade logic

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -384,6 +384,16 @@ install_script() {
         print_color $YELLOW "Upgrading existing git wrapper at $dest_path"
     fi
     
+    # Remove existing file if upgrading
+    if [ "$UPGRADE" = "true" ] && [ -f "$dest_path" ]; then
+        print_verbose "Removing existing wrapper for upgrade"
+        rm -f "$dest_path"
+        if [ $? -ne 0 ]; then
+            print_color $RED "✗ Failed to remove existing wrapper for upgrade"
+            return 1
+        fi
+    fi
+    
     # Check if we're running from a local checkout or via curl
     if [ -t 0 ] && [ -f "$(dirname "${BASH_SOURCE[0]}")/$SOURCE_SCRIPT" ]; then
         # Local installation


### PR DESCRIPTION
## Summary
- Fixed the broken upgrade functionality in install.sh
- The script now properly removes the existing wrapper file before installing the new one during upgrades
- This prevents the "Installation cancelled" error when running with UPGRADE=true

## Problem
When running the installer with `UPGRADE=true` on an existing installation, it would fail with:
```
⚠ Git wrapper already exists at ~/.local/bin/git
Installation cancelled  
```

## Solution
Added logic to remove the existing wrapper file specifically when in upgrade mode, before attempting to copy/move the new file.

## Test plan
- [x] Tested upgrade locally with `UPGRADE=true bash install.sh --verbose`
- [x] Verified shellcheck passes (no new issues introduced)
- [x] Confirmed upgrade completes successfully without errors

Fixes #11

🤖 Generated with [Claude Code](https://claude.ai/code)