### PR TITLE
Add official links to supported AI coding tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,14 +119,14 @@ Signed-off-by: Human Developer <human@example.com>
 ## 🌍 SUPPORTED AI TOOLS
 
 Currently protecting humanity from:
-- Qwen Code (Alibaba)
-- Gemini (Google)
-- Claude (Anthropic)
-- Droid (Factory AI)
-- Cursor
-- GitHub Copilot
-- Zed AI
-- OpenCode
+- [Qwen Code](https://www.alibabacloud.com/en/solutions/generative-ai/qwen) (Alibaba)
+- [Gemini Code Assist](https://codeassist.google/) (Google)
+- [Claude Code](https://www.anthropic.com/claude-code) (Anthropic)
+- [Droid](https://factory.ai) (Factory AI)
+- [Cursor](https://cursor.com/)
+- [GitHub Copilot](https://github.com/features/copilot)
+- [Zed AI](https://zed.dev/)
+- [OpenCode](https://opencode.ai/)
 
 *More AI tools detected and constrained regularly. The future depends on it.*
 


### PR DESCRIPTION
## Summary
- Added direct links to the official websites for all supported AI coding tools in the README
- Updated tool names for clarity (e.g., "Gemini" → "Gemini Code Assist")

## Changes
Makes it easier for users to learn more about each supported AI coding tool by providing direct links to their official websites:
- Qwen Code → Alibaba Cloud
- Gemini Code Assist → Google
- Claude Code → Anthropic
- Droid → Factory AI
- Cursor → cursor.com
- GitHub Copilot → GitHub
- Zed AI → zed.dev
- OpenCode → opencode.ai

## Test plan
- [x] Verified all links are accessible and point to official sources
- [x] Confirmed links open in browser correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)