### PR TITLE
Fix: avoid false positives in cursor ide terminals

### DIFF
--- a/executable_git
+++ b/executable_git
@@ -44,7 +44,7 @@ check_env_vars() {
     fi
 
     # Cursor detection
-    if [ -n "$CURSOR_AI" ]; then
+    if [ -n "$CURSOR_AGENT" ]; then
         detected="$detected cursor"
     fi
 
@@ -160,7 +160,7 @@ check_ps_tree() {
         if process_contains "$current_pid" "opencode"; then
             detected="$detected opencode"
         fi
-        if process_contains "$current_pid" "cursor"; then
+        if process_contains "$current_pid" "cursor-agent"; then
             detected="$detected cursor"
         fi
         # Kimi CLI detection - look for kimi in process command


### PR DESCRIPTION
Current Cursor detection triggers false positives when a human user is working in a terminal inside the cursor IDE.

Changes to look for `cursor-agent` process (cursor cli) and the `CURSOR_AGENT` env var, which looks to be set both by cursor-agent cli and when using agent mode inside the IDE.